### PR TITLE
Fix Best practice Notice in 404 WordPress Page

### DIFF
--- a/includes/fixes-permalinks.php
+++ b/includes/fixes-permalinks.php
@@ -231,9 +231,11 @@ function wpp_pre_get_posts( $query ) {
 		preg_match_all( '!\d+!', $var, $matches );
 		$var = $matches[0];
 
-		$query->set( 'year', $var[0] );
-		$query->set( 'monthnum', $var[1] );
-		$query->set( 'day', $var[2] );
+		if(!empty($var) and is_array($var)) {
+			$query->set( 'year', $var[0] );
+			$query->set( 'monthnum', $var[1] );
+			$query->set( 'day', $var[2] );
+		}
 		$query->is_404              = false;
 		$query->query_vars['error'] = '';
 	}//else


### PR DESCRIPTION
Fix php notice in 404 wordpress page:

Notice: Undefined offset: 0 in C:\..\wp-content\plugins\wp-parsidate\includes\fixes-permalinks.php on line 247
Notice: Undefined offset: 1 in C:\..\wp-content\plugins\wp-parsidate\includes\fixes-permalinks.php on line 248
Notice: Undefined offset: 2 in C:\..\wp-content\plugins\wp-parsidate\includes\fixes-permalinks.php on line 250