### PR TITLE
apply `disable_months_dropdown` filter

### DIFF
--- a/includes/admin/lists-fix.php
+++ b/includes/admin/lists-fix.php
@@ -61,6 +61,10 @@ function wpp_admin_posts_where($where)
 function wpp_restrict_posts()
 {
     global $post_type, $post_status, $wpdb, $persian_month_names;
+    
+    if ( apply_filters( 'disable_months_dropdown', false, $post_type ) ) {
+        return;
+    }
 
     $post_status_w = "AND post_status <> 'auto-draft'";
     if ($post_status != "") {


### PR DESCRIPTION
wp-parsidate DatePicker show if user disable dropdown by filter in edit.php.

please see:
https://developer.wordpress.org/reference/classes/wp_list_table/months_dropdown/
line: 594