### PR TITLE
Fix for loading Vazir font in block editor

### DIFF
--- a/includes/admin/styles-fix.php
+++ b/includes/admin/styles-fix.php
@@ -32,9 +32,10 @@ add_action( 'admin_print_styles-theme-editor.php', 'wpp_fix_editor_rtl', 10 );
  * @since               2.0
  */
 function wpp_fix_tinymce_font() {
+    if( wpp_is_active( 'enable_fonts' ) ){
 	$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG || wpp_is_active( 'dev_mode' ) ? '' : '.min';
-
 	add_editor_style( WP_PARSI_URL . "assets/css/editor$suffix.css" );
+    }
 }
 
 add_filter( 'init', 'wpp_fix_tinymce_font', 9 );


### PR DESCRIPTION
When we don't select Vazir font and we enable editor styles in theme:
add_theme_support( 'editor-styles' );
The plugin loads Vazir font in Block editor and changes font sizes and font family
So this fix ensures which Vazir font loads only when we select the option in plugins settings