### PR TITLE
Update fixes-dates.php

### DIFF
--- a/includes/fixes-dates.php
+++ b/includes/fixes-dates.php
@@ -168,7 +168,7 @@ function wpp_fix_comment_date( $time, $format = '' ) {
 function wpp_fix_i18n( $date, $format, $timestamp, $gmt ) {
 	global $post;
 
-	$post_id = ! empty( $post ) ? $post->ID : null;
+	$post_id = (is_object($post) && isset($post->ID)) ? $post->ID : null;
 
 	if ( ! disable_wpp() ) {
 		return $format;


### PR DESCRIPTION
Here's the **updated line**:
`$post_id = (is_object($post) && isset($post->ID)) ? $post->ID : null;`

This change adds a check to ensure `$post` is an object before accessing its `ID` property. If `$post` is not an object, `$post_id` will be set to `null`, avoiding the warning.

Previously `$post->ID` was being accessed, but it appears that `$post` might be an integer or something other than an object, leading to the warning.

`$post_id = ! empty( $post ) ? $post->ID : null;`