### PR TITLE
حل مشکل نمایش تاریخ‌ها با فرمت ISO 8601

### DIFF
--- a/includes/fixes-dates.php
+++ b/includes/fixes-dates.php
@@ -63,7 +63,7 @@ function wpp_fix_post_date( $time, $format = '', $post = null ) {
 	}
 
 	if ( 'c' === $format || ! disable_wpp() ) {
-		return date( $format, strtotime( $post->post_modified ) );
+		return date( $format, strtotime( $post->post_date ) );
 	}
 
 	return parsidate( $format, date( 'Y-m-d H:i:s', strtotime( $post->post_date ) ), ! wpp_is_active( 'conv_dates' ) ? 'eng' : 'per' );

--- a/includes/fixes-dates.php
+++ b/includes/fixes-dates.php
@@ -17,8 +17,9 @@ if ( get_locale() === 'fa_IR' && wpp_is_active( 'persian_date' ) ) {
 	add_filter( 'the_date', 'wpp_fix_post_date', 10, 3 );
 	add_filter( 'get_the_time', 'wpp_fix_get_the_time', 10, 3 );
 	add_filter( 'get_the_date', 'wpp_fix_post_date', 100, 3 );
+	add_filter( 'get_the_modified_date', 'wpp_fix_modified_date', 10, 3 );
 	add_filter( 'get_comment_time', 'wpp_fix_comment_time', 10, 2 );
-	add_filter( 'get_comment_date', 'wpp_fix_comment_date', 10, 2 );
+	add_filter( 'get_comment_date', 'wpp_fix_comment_date', 10, 3 );
 	//add_filter('get_post_modified_time', 'wpp_fix_post_modified_time', 10, 3);
 	add_filter( 'date_i18n', 'wpp_fix_i18n', 10, 4 );
 
@@ -61,11 +62,33 @@ function wpp_fix_post_date( $time, $format = '', $post = null ) {
 		$format = get_option( 'date_format' );
 	}
 
-	if ( ! disable_wpp() ) {
+	if ( 'c' === $format || ! disable_wpp() ) {
 		return date( $format, strtotime( $post->post_modified ) );
 	}
 
 	return parsidate( $format, date( 'Y-m-d H:i:s', strtotime( $post->post_date ) ), ! wpp_is_active( 'conv_dates' ) ? 'eng' : 'per' );
+}
+
+/**
+ * Fixes post modified date and returns to Jalali format
+ *
+ * @param string $time Post modified time
+ * @param string $format Date format
+ * @param WP_Post|null	$post	WP_Post object or null if no post is found.
+ *
+ * @return string Formatted date
+ * @author Yousef Mahmoudi
+ */
+function wpp_fix_modified_date( $time, $format, $post ) {
+	if ( empty( $post ) ) {
+		return $time;
+	}
+	
+	if ( 'c' === $format ) {
+		return date( $format, strtotime( $post->post_modified ) );
+	}
+	
+	return $time;
 }
 
 /**
@@ -174,9 +197,7 @@ function wpp_fix_comment_time( $time, $format = '' ) {
  *
  * @return          string Formatted date
  */
-function wpp_fix_comment_date( $time, $format = '' ) {
-	global $comment;
-
+function wpp_fix_comment_date( $time, $format = '', $comment ) {
 	if ( empty( $comment ) ) {
 		return $time;
 	}
@@ -184,7 +205,7 @@ function wpp_fix_comment_date( $time, $format = '' ) {
 	if ( empty( $format ) ) {
 		$format = get_option( 'date_format' );
 	}
-	if ( ! disable_wpp() ) {
+	if ( 'c' === $format || ! disable_wpp() ) {
 		return date( $format, strtotime( $comment->comment_date ) );
 	}
 


### PR DESCRIPTION
فرمت تاریخ های ISO 8601 یا C باید به این شکل باشه:
2004-02-12T15:19:21+00:00
ولی زمانی که افزونه پارسی دیت فعال باشه این تاریخ به شمسی تبدیل میشن و اگه تبدیل اعداد در تاریخ هم فعال باشه عددها فارسی میشن
![Screen Shot 2025-02-11 at 11 56 08 AM](https://github.com/user-attachments/assets/1bc48059-99d2-433c-9a4e-4f1ed1c5a083)
![Screen Shot 2025-02-11 at 11 56 23 AM](https://github.com/user-attachments/assets/4b3a6a33-3267-481d-a5a2-d108b7e07bf4)

تو قالب های کلاسیک توسعه دهنده میتونه به هر شکلی که میخواد نمایش بده ولی توی قالب هایی که با گوتنبرگ کار میکنن و از بلوک های تاریخ استفاده میشه این مشکل وجود داره چون datetime با فرمت C دارن. [مثال](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-date/index.php#L37)

این تغییرات مشکلات بلوک های تاریخ، تاریخ ویرایش، تاریخ دیدگاه و زمانی که تاریخ با فرمت ISO 8601 فراخوانی بشن رو حل میکنه
![Screen Shot 2025-02-11 at 12 40 11 PM](https://github.com/user-attachments/assets/0a332f45-8b00-4c0f-8109-841652ddb0b5)

