### PR TITLE
Fix Rank Math date formatting and dashicons visibility with Vazir font

### DIFF
--- a/assets/css/vazir-font.css
+++ b/assets/css/vazir-font.css
@@ -32,7 +32,7 @@ code {
 
 body#tinymce.wp-editor,
 .rtl .editor-styles-wrapper,
-.rtl .edit-post-visual-editor *,
+.rtl .edit-post-visual-editor *:not(.dashicons),
 .rtl .components-notice__content,
 #wpseo_meta *,
 .edit-post-sidebar *,

--- a/includes/plugins/rank-math.php
+++ b/includes/plugins/rank-math.php
@@ -75,6 +75,16 @@ if (!class_exists('WPP_Rank_Math')) {
                         }
                     }
                 }
+
+                // Fix datePublished and dateModified for BlogPosting
+                if (isset($item['@type']) && ($item['@type'] === 'BlogPosting' || $item['@type'] === 'Article')) {
+                    if (!empty($item['datePublished'])) {
+                        $data[$key]['datePublished'] = $this->convert_date_time($item['datePublished']);
+                    }
+                    if (!empty($item['dateModified'])) {
+                        $data[$key]['dateModified'] = $this->convert_date_time($item['dateModified']);
+                    }
+                }
             }
 
             return $data;


### PR DESCRIPTION
This pull request addresses multiple issues:
- Converts datePublished and dateModified to ISO8601 in Rank Math JSON schema (https://github.com/wordpress-parsi/wp-parsidate/issues/214)
- Fixes visibility of dashicons when Vazir font is enabled ((https://github.com/wordpress-parsi/wp-parsidate/issues/280))

Changes Made
- Improved schema output for Rank Math by properly formatting datePublished and dateModified fields.
- Updated CSS selectors to ensure .dashicons icons retain visibility when Vazir font is active under RTL contexts.