### PR TITLE
fix: Implicitly nullable parameter declarations deprecated in PHP 8.4

### DIFF
--- a/inc/Helper/Assets.php
+++ b/inc/Helper/Assets.php
@@ -80,7 +80,7 @@ class Assets {
    *
    * @return string HTML SVG string
    */
-  public static function setSvgDimensions( string $svg, int $width, int $height = null, bool $clean = true ): string {
+  public static function setSvgDimensions( string $svg, int $width, ?int $height = null, bool $clean = true ): string {
     if ( is_null( $height ) ) {
       $height = $width;
     }

--- a/inc/Helper/JSON.php
+++ b/inc/Helper/JSON.php
@@ -42,7 +42,7 @@ class JSON {
    * <i>json</i> cannot be decoded or if the encoded
    * data is deeper than the recursion limit.
    */
-  public static function decode( string $json, bool $associative = null, int $depth = 512, int $flags = 0 ) {
+  public static function decode( string $json, ?bool $associative = null, int $depth = 512, int $flags = 0 ) {
     try {
       return json_decode( $json, $associative, $depth, JSON_THROW_ON_ERROR | $flags );
     } catch ( Throwable $e ) {

--- a/inc/Helper/Nonce.php
+++ b/inc/Helper/Nonce.php
@@ -26,7 +26,7 @@ class Nonce {
    *                    2 if the nonce is valid and generated between 12-24 hours ago.
    *                    False if the nonce is invalid.
    */
-  public static function verify( string $nonce = null, $action = WP_PARSI_KEY ) {
+  public static function verify( ?string $nonce = null, $action = WP_PARSI_KEY ) {
     $nonce = is_null( $nonce ) && isset( $_POST['nonce'] ) ? Sanitizing::text( wp_unslash( Param::post( 'nonce' ) ) ) : $nonce;
     if ( is_null( $nonce ) ) {
       return false;

--- a/inc/Settings/Settings.php
+++ b/inc/Settings/Settings.php
@@ -60,7 +60,7 @@ class Settings {
     return update_option( $optionsName, $newOptions, false );
   }
 
-  public static function get( string $key = null, $default = null, $optionsName = null, bool $useCache = true ) {
+  public static function get( ?string $key = null, $default = null, $optionsName = null, bool $useCache = true ) {
     $optionsName = is_string( $optionsName ) ? WP_PARSI_KEY . '_' . $optionsName : WP_PARSI_KEY;
     $options     = Cache::get( 'options_' . $optionsName, false );
 


### PR DESCRIPTION
در جهت سازگاری با PHP 8.4 و رفع هشدارهای Deprecated، تایپ پارامتر های نال‌پذیر به صورت صریح تعریف شدند.