### PR TITLE
Update FixTitle.php

### DIFF
--- a/inc/App/Core/FixTitle.php
+++ b/inc/App/Core/FixTitle.php
@@ -12,50 +12,50 @@ use WPParsidate\Helper\Number;
 use WPParsidate\Settings\Settings;
 
 class FixTitle {
-    public function __construct() {
-        add_filter( 'wp_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX, 3 );
-        add_filter( 'pre_get_document_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX ); // WP 4.4+
+  public function __construct() {
+    add_filter( 'wp_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX, 3 );
+    add_filter( 'pre_get_document_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX ); // WP 4.4+
+  }
+
+  /**
+   * Fixes titles for archives
+   *
+   * @param string|null $title Archive title.
+   * @param string $sep Separator.
+   * @param string $seplocation Separator location.
+   *
+   * @return string
+   */
+  public function fixWpTitle( ?string $title, $sep = '-', $seplocation = 'right' ): string {
+    global $wp_query;
+
+    // pre_get_document_title may return null.
+    $title ??= '';
+
+    $query = $wp_query->query ?? [];
+
+    if ( ! is_archive() || ! Settings::get( 'persian_date', false ) ) {
+      return $title;
     }
 
-    /**
-     * Fixes titles for archives
-     *
-     * @param string|null $title Archive title.
-     * @param string      $sep Separator.
-     * @param string      $seplocation Separator location.
-     *
-     * @return string
-     */
-    public function fixWpTitle( ?string $title, $sep = '-', $seplocation = 'right' ): string {
-        global $wp_query;
-
-        // pre_get_document_title may return null.
-        $title ??= '';
-
-        $query = $wp_query->query ?? [];
-
-        if ( ! is_archive() || ! Settings::get( 'persian_date', false ) ) {
-            return $title;
-        }
-
-        if ( $seplocation === 'right' ) {
-            $query = array_reverse( $query );
-        }
-
-        if ( isset( $query['monthnum'] ) ) {
-            $monthsName = Names::getMonths();
-
-            if ( isset( $monthsName[ (int) $query['monthnum'] ] ) ) {
-                $query['monthnum'] = $monthsName[ (int) $query['monthnum'] ];
-            }
-
-            $title = implode( ' ', $query ) . " $sep " . get_bloginfo( 'name' );
-        }
-
-        if ( Settings::get( 'conv_page_title', false ) ) {
-            $title = Number::fixNumber( $title );
-        }
-
-        return (string) $title;
+    if ( $seplocation === 'right' ) {
+      $query = array_reverse( $query );
     }
+
+    if ( isset( $query['monthnum'] ) ) {
+      $monthsName = Names::getMonths();
+
+      if ( isset( $monthsName[ (int) $query['monthnum'] ] ) ) {
+        $query['monthnum'] = $monthsName[ (int) $query['monthnum'] ];
+      }
+
+      $title = implode( ' ', $query ) . " $sep " . get_bloginfo( 'name' );
+    }
+
+    if ( Settings::get( 'conv_page_title', false ) ) {
+      $title = Number::fixNumber( $title );
+    }
+
+    return (string) $title;
+  }
 }

--- a/inc/App/Core/FixTitle.php
+++ b/inc/App/Core/FixTitle.php
@@ -12,7 +12,6 @@ use WPParsidate\Helper\Number;
 use WPParsidate\Settings\Settings;
 
 class FixTitle {
-
     public function __construct() {
         add_filter( 'wp_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX, 3 );
         add_filter( 'pre_get_document_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX ); // WP 4.4+
@@ -50,7 +49,7 @@ class FixTitle {
                 $query['monthnum'] = $monthsName[ (int) $query['monthnum'] ];
             }
 
-            $title = implode( ' ', $query ) . " {$sep} " . get_bloginfo( 'name' );
+            $title = implode( ' ', $query ) . " $sep " . get_bloginfo( 'name' );
         }
 
         if ( Settings::get( 'conv_page_title', false ) ) {

--- a/inc/App/Core/FixTitle.php
+++ b/inc/App/Core/FixTitle.php
@@ -12,43 +12,51 @@ use WPParsidate\Helper\Number;
 use WPParsidate\Settings\Settings;
 
 class FixTitle {
-  public function __construct() {
-    add_filter( 'wp_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX, 3 );
-    add_filter( 'pre_get_document_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX ); // WP 4.4+
-  }
 
-  /**
-   * Fixes titles for archives
-   *
-   * @param string $title Archive title
-   * @param string $sep Separator
-   * @param string $seplocation Separator location
-   *
-   * @return                  string New archive title
-   */
-  public function fixWpTitle( $title, $sep = '-', $seplocation = 'right' ): string {
-    global $wp_query;
-
-    $query = $wp_query->query;
-
-    if ( ! is_archive() || ! Settings::get( 'persian_date', false ) ) {
-      return $title;
+    public function __construct() {
+        add_filter( 'wp_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX, 3 );
+        add_filter( 'pre_get_document_title', [ $this, 'fixWpTitle' ], PHP_INT_MAX ); // WP 4.4+
     }
 
-    if ( $seplocation === 'right' ) {
-      $query = array_reverse( $query );
-    }
+    /**
+     * Fixes titles for archives
+     *
+     * @param string|null $title Archive title.
+     * @param string      $sep Separator.
+     * @param string      $seplocation Separator location.
+     *
+     * @return string
+     */
+    public function fixWpTitle( ?string $title, $sep = '-', $seplocation = 'right' ): string {
+        global $wp_query;
 
-    if ( isset( $query['monthnum'] ) ) {
-      $monthsName        = Names::getMonths();
-      $query['monthnum'] = $monthsName[ (int) $query['monthnum'] ];
-      $title             = implode( " ", $query ) . " $sep " . get_bloginfo( "name" );
-    }
+        // pre_get_document_title may return null.
+        $title ??= '';
 
-    if ( Settings::get( 'conv_page_title', false ) ) {
-      $title = Number::fixNumber( $title );
-    }
+        $query = $wp_query->query ?? [];
 
-    return $title;
-  }
+        if ( ! is_archive() || ! Settings::get( 'persian_date', false ) ) {
+            return $title;
+        }
+
+        if ( $seplocation === 'right' ) {
+            $query = array_reverse( $query );
+        }
+
+        if ( isset( $query['monthnum'] ) ) {
+            $monthsName = Names::getMonths();
+
+            if ( isset( $monthsName[ (int) $query['monthnum'] ] ) ) {
+                $query['monthnum'] = $monthsName[ (int) $query['monthnum'] ];
+            }
+
+            $title = implode( ' ', $query ) . " {$sep} " . get_bloginfo( 'name' );
+        }
+
+        if ( Settings::get( 'conv_page_title', false ) ) {
+            $title = Number::fixNumber( $title );
+        }
+
+        return (string) $title;
+    }
 }

--- a/inc/App/Core/FixTitle.php
+++ b/inc/App/Core/FixTitle.php
@@ -32,6 +32,15 @@ class FixTitle {
     // pre_get_document_title may return null.
     $title ??= '';
 
+    /**
+     * Filters the separator for the document title.
+     *
+     * @since WP 4.4.0
+     *
+     * @param string $sep Document title separator. Default '-'.
+     */
+    $sep = apply_filters( 'document_title_separator', $sep );
+
     $query = $wp_query->query ?? [];
 
     if ( ! is_archive() || ! Settings::get( 'persian_date', false ) ) {


### PR DESCRIPTION
Fix: Prevent TypeError in FixTitle::fixWpTitle() when $title is null.

In some cases, the pre_get_document_title filter may pass a null value instead of a string (for example, depending on WordPress core or SEO plugins such as Rank Math). Since fixWpTitle() declares a string return type, returning null causes a fatal TypeError on PHP 8+.

This change safely casts the return value to a string (or falls back to an empty string) to ensure the method always satisfies its declared return type without changing the existing title generation logic