### PR TITLE
fix: declare WooCommerce feature compatibility unconditionally

### DIFF
--- a/inc/App/Integration/WooCommerce.php
+++ b/inc/App/Integration/WooCommerce.php
@@ -22,6 +22,12 @@ class WooCommerce extends Addon {
 
   public string $currentTab = 'woocommerce';
 
+  public function __construct() {
+    parent::__construct();
+
+    add_action( 'before_woocommerce_init', [ $this, 'declareCompatibility' ] );
+  }
+
   public function initM1Action(): void {
     add_filter( 'wp_parsidate_' . $this->addonID . '_settings', [ $this, 'addTabSettings' ] );
     add_filter( 'wp_parsidate_' . $this->addonID . '_tab_display_notice', '__return_false' );
@@ -121,6 +127,18 @@ class WooCommerce extends Addon {
 
   public function convertEmailContentNumbers( $message ): string {
     return NumberConverter::convertContent( $message );
+  }
+
+  /**
+   * Declare WooCommerce feature compatibility
+   *
+   * @return void
+   */
+  public function declareCompatibility() {
+    if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', WP_PARSI_ROOT, true );
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'product_instance_caching', WP_PARSI_ROOT, true );
+    }
   }
 
   /**

--- a/inc/App/Integration/WooCommerce.php
+++ b/inc/App/Integration/WooCommerce.php
@@ -10,7 +10,6 @@ namespace WPParsidate\App\Integration;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WPParsidate\Addons\Addon;
 use WPParsidate\App\Integration\WooCommerce\{WcGateways, WooCommerceCitySelect};
 use WPParsidate\Helper\{Assets, Date, Debug, Number, NumberConverter, Param, Templates};
@@ -131,11 +130,6 @@ class WooCommerce extends Addon {
     // WooCommerce checkout city select in classic form
     if ( $this->getSetting( 'dropdown_cities', false ) && ! \WPParsidate\Helper\WooCommerce::hasBlockInPage( wc_get_page_id( 'checkout' ), 'woocommerce/checkout' ) ) {
       new WooCommerceCitySelect();
-    }
-
-    if ( class_exists( FeaturesUtil::class ) ) {
-      FeaturesUtil::declare_compatibility( 'custom_order_tables', WP_PARSI_ROOT, true );
-      FeaturesUtil::declare_compatibility( 'product_instance_caching', WP_PARSI_ROOT, true );
     }
   }
 

--- a/wp-parsidate.php
+++ b/wp-parsidate.php
@@ -69,7 +69,6 @@ final class WP_Parsidate {
   public function __construct() {
     $this->define();
     $this->include();
-    $this->compatibility();
     $this->instance();
   }
 
@@ -127,28 +126,6 @@ final class WP_Parsidate {
    */
   private function include(): void {
     require_once __DIR__ . '/vendor/autoload.php';
-  }
-
-  /**
-   * Declare WooCommerce feature compatibility
-   *
-   * This has to run unconditionally, outside of the addon system.
-   * Addon::isActivated() gates initM1Action(), which is where the
-   * 'before_woocommerce_init' listener used to be registered. When the
-   * WooCommerce addon was disabled the declaration was therefore never made,
-   * WooCommerce reported the plugin as "uncertain" and refused to enable HPOS.
-   *
-   * @return void
-   */
-  private function compatibility(): void {
-    add_action( 'before_woocommerce_init', static function () {
-      if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-        return;
-      }
-
-      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', WP_PARSI_ROOT, true );
-      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'product_instance_caching', WP_PARSI_ROOT, true );
-    } );
   }
 
   /**

--- a/wp-parsidate.php
+++ b/wp-parsidate.php
@@ -69,6 +69,7 @@ final class WP_Parsidate {
   public function __construct() {
     $this->define();
     $this->include();
+    $this->compatibility();
     $this->instance();
   }
 
@@ -126,6 +127,28 @@ final class WP_Parsidate {
    */
   private function include(): void {
     require_once __DIR__ . '/vendor/autoload.php';
+  }
+
+  /**
+   * Declare WooCommerce feature compatibility
+   *
+   * This has to run unconditionally, outside of the addon system.
+   * Addon::isActivated() gates initM1Action(), which is where the
+   * 'before_woocommerce_init' listener used to be registered. When the
+   * WooCommerce addon was disabled the declaration was therefore never made,
+   * WooCommerce reported the plugin as "uncertain" and refused to enable HPOS.
+   *
+   * @return void
+   */
+  private function compatibility(): void {
+    add_action( 'before_woocommerce_init', static function () {
+      if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+        return;
+      }
+
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', WP_PARSI_ROOT, true );
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'product_instance_caching', WP_PARSI_ROOT, true );
+    } );
   }
 
   /**


### PR DESCRIPTION
### Problem

WooCommerce lists WP-Parsidate under "uncertain" in
**WooCommerce → Settings → Advanced → Features → Order data storage**,
which prevents store owners from enabling High Performance Order Storage.

### Root cause

The compatibility declarations live in `Integration\WooCommerce::beforeWooCommerceInit()`,
and the `before_woocommerce_init` listener that triggers them is registered in
`initM1Action()`:

https://github.com/wordpress-parsi/wp-parsidate/blob/master/inc/App/Integration/WooCommerce.php#L31

`Addon::registerInitM1Action()` only calls `initM1Action()` when
`Addon::isActivated()` returns true:

https://github.com/wordpress-parsi/wp-parsidate/blob/master/inc/Addons/Addon.php#L117

`isActivated()` returns false unless `internal_addon_woocommerce` is set to `1`.

So on any site where the WooCommerce addon is not enabled, the listener is never
registered, `declare_compatibility()` never runs, and WooCommerce has no way to
know the plugin is compatible.

### Reproduce

1. Fresh install, leave the WooCommerce addon disabled
2. Go to WooCommerce → Settings → Advanced → Features
3. WP-Parsidate is listed as incompatible / uncertain and HPOS cannot be enabled

Verified at runtime: no `wp-parsidate` callback is present in
`$wp_filter['before_woocommerce_init']`, while every other compatible plugin
on the same site is.

### Fix

Move the declaration to the plugin bootstrap so it always runs.

Compatibility describes the plugin as a whole, not a single addon. When the
addon is disabled the plugin executes no order-storage code at all, so
declaring compatibility is correct in both states. This also matches
WooCommerce's own guidance, which is to declare from the main plugin file.

`Integration\WooCommerce::beforeWooCommerceInit()` keeps its remaining
responsibility (the classic-checkout city select) and the now-unused
`FeaturesUtil` import is removed.

### Testing

WordPress 7.0.2, WooCommerce 11.0.0, PHP 8.3, WP-Parsidate 6.2.1.

Before: `FeaturesUtil::get_compatible_plugins_for_feature('custom_order_tables')`
returns `wp-parsidate/wp-parsidate.php` under `uncertain`.

After: it returns under `compatible`, with the WooCommerce addon still disabled.
HPOS pre-enable checks pass. No regressions on shop, cart or admin order screens.